### PR TITLE
Fix nil dereference in case when any labels added to previously unlabeled secret

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/panjf2000/ants/v2 v2.4.8
+	github.com/prometheus/client_golang v1.7.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
@@ -76,7 +77,6 @@ require (
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.7.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.10.0 // indirect
 	github.com/prometheus/procfs v0.2.0 // indirect

--- a/pkg/backend/helpers.go
+++ b/pkg/backend/helpers.go
@@ -41,12 +41,20 @@ func secretDiffer(src, dest *v1.Secret) bool {
 }
 
 func copySecret(src, dest *v1.Secret) {
+	if src.Labels != nil {
+		dest.Labels = make(map[string]string)
+	}
 	for k, v := range src.Labels {
 		dest.Labels[k] = v
+	}
+
+	if src.Annotations != nil {
+		dest.Annotations = make(map[string]string)
 	}
 	for k, v := range src.Annotations {
 		dest.Annotations[k] = v
 	}
+
 	dest.Data = make(map[string][]byte)
 	for k, v := range src.Data {
 		dataCopy := make([]byte, len(v))


### PR DESCRIPTION
```
panic: assignment to entry in nil map

goroutine 342 [running]:
github.com/ktsstudio/mirrors/pkg/backend.copySecret(...)
	/workspace/pkg/backend/helpers.go:45
github.com/ktsstudio/mirrors/pkg/backend.(*NamespacesDest).syncOneToNamespace(0xc0005f86c0, {0x1898328, 0xc000478fc0}, 0xc002fbe8c0, {{0xc000122cc0?, 0xc00005df38?}, {0xc00049acc0?, 0xc000584be8?}})
	/workspace/pkg/backend/dest_namespaces.go:129 +0x465
github.com/ktsstudio/mirrors/pkg/backend.(*NamespacesDest).Sync.func1.1()
	/workspace/pkg/backend/dest_namespaces.go:50 +0x88
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x67
created by golang.org/x/sync/errgroup.(*Group).Go
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x8d
```